### PR TITLE
Feature/support html text on questions

### DIFF
--- a/ResearchKit/Common/ORKHeadlineLabel.m
+++ b/ResearchKit/Common/ORKHeadlineLabel.m
@@ -62,7 +62,6 @@
 
 // Nasty override (hack)
 - (void)updateAppearance {
-    self.font = [self defaultFont];
     [self invalidateIntrinsicContentSize];
 }
 

--- a/ResearchKit/Common/ORKLabel.m
+++ b/ResearchKit/Common/ORKLabel.m
@@ -66,7 +66,6 @@
 }
 
 - (void)updateAppearance {
-    self.font = [[self class] defaultFont];
     [self invalidateIntrinsicContentSize];
 }
 

--- a/ResearchKit/Common/ORKQuestionStepView.m
+++ b/ResearchKit/Common/ORKQuestionStepView.m
@@ -53,11 +53,39 @@
     self.headerView.instructionLabel.hidden = ![_questionStep text].length;
     
     self.headerView.captionLabel.useSurveyMode = step.useSurveyMode;
-    self.headerView.captionLabel.text = _questionStep.title;
-    self.headerView.instructionLabel.text = _questionStep.text;
+    self.headerView.captionLabel.attributedText = [self getAttributedQuestionTitle];
+    self.headerView.instructionLabel.attributedText = [self getAttributedQuestionText];
     self.continueSkipContainer.optional = _questionStep.optional;
     
     [self.continueSkipContainer updateContinueAndSkipEnabled];
+}
+
+- (NSAttributedString *)getAttributedQuestionTitle {
+    NSString *openFont = @"<font size='6' style='font-family:HelveticaNeue-Light'>";
+    NSString *closeFont = @"</font>";
+    NSString *customTitle = [NSString stringWithFormat:@"%@%@%@", openFont, self.questionStep.title, closeFont];
+    NSError *error = nil;
+    NSMutableAttributedString *attts = [[NSMutableAttributedString alloc] initWithData:[customTitle dataUsingEncoding:NSUnicodeStringEncoding] options:@{NSDocumentTypeDocumentAttribute: NSHTMLTextDocumentType} documentAttributes:nil error:&error];
+    NSRange range = NSMakeRange(0, attts.length);
+    NSMutableParagraphStyle *style =  [[NSMutableParagraphStyle alloc] init];
+    style.alignment = NSTextAlignmentCenter;
+    [attts addAttribute:NSParagraphStyleAttributeName value:style range:range];
+    
+    return attts;
+}
+
+- (NSAttributedString *)getAttributedQuestionText {
+    NSString *openFont = @"<font size='4' style='font-family:HelveticaNeue-Light'>";
+    NSString *closeFont = @"</font>";
+    NSString *customTitle = [NSString stringWithFormat:@"%@%@%@", openFont, self.questionStep.text, closeFont];
+    NSError *error = nil;
+    NSMutableAttributedString *attts = [[NSMutableAttributedString alloc] initWithData:[customTitle dataUsingEncoding:NSUnicodeStringEncoding] options:@{NSDocumentTypeDocumentAttribute: NSHTMLTextDocumentType} documentAttributes:nil error:&error];
+    NSRange range = NSMakeRange(0, attts.length);
+    NSMutableParagraphStyle *style =  [[NSMutableParagraphStyle alloc] init];
+    style.alignment = NSTextAlignmentCenter;
+    [attts addAttribute:NSParagraphStyleAttributeName value:style range:range];
+    
+    return attts;
 }
 
 #pragma mark - Accessibility

--- a/ResearchKit/Common/ORKQuestionStepView.m
+++ b/ResearchKit/Common/ORKQuestionStepView.m
@@ -53,39 +53,11 @@
     self.headerView.instructionLabel.hidden = ![_questionStep text].length;
     
     self.headerView.captionLabel.useSurveyMode = step.useSurveyMode;
-    self.headerView.captionLabel.attributedText = [self getAttributedQuestionTitle];
-    self.headerView.instructionLabel.attributedText = [self getAttributedQuestionText];
+    self.headerView.captionLabel.attributedText = [self.headerView getAttributedText:self.questionStep.title withFontSize:6];
+    self.headerView.instructionLabel.attributedText = [self.headerView getAttributedText:self.questionStep.text withFontSize:4];
     self.continueSkipContainer.optional = _questionStep.optional;
     
     [self.continueSkipContainer updateContinueAndSkipEnabled];
-}
-
-- (NSAttributedString *)getAttributedQuestionTitle {
-    NSString *openFont = @"<font size='6' style='font-family:HelveticaNeue-Light'>";
-    NSString *closeFont = @"</font>";
-    NSString *customTitle = [NSString stringWithFormat:@"%@%@%@", openFont, self.questionStep.title, closeFont];
-    NSError *error = nil;
-    NSMutableAttributedString *attts = [[NSMutableAttributedString alloc] initWithData:[customTitle dataUsingEncoding:NSUnicodeStringEncoding] options:@{NSDocumentTypeDocumentAttribute: NSHTMLTextDocumentType} documentAttributes:nil error:&error];
-    NSRange range = NSMakeRange(0, attts.length);
-    NSMutableParagraphStyle *style =  [[NSMutableParagraphStyle alloc] init];
-    style.alignment = NSTextAlignmentCenter;
-    [attts addAttribute:NSParagraphStyleAttributeName value:style range:range];
-    
-    return attts;
-}
-
-- (NSAttributedString *)getAttributedQuestionText {
-    NSString *openFont = @"<font size='4' style='font-family:HelveticaNeue-Light'>";
-    NSString *closeFont = @"</font>";
-    NSString *customTitle = [NSString stringWithFormat:@"%@%@%@", openFont, self.questionStep.text, closeFont];
-    NSError *error = nil;
-    NSMutableAttributedString *attts = [[NSMutableAttributedString alloc] initWithData:[customTitle dataUsingEncoding:NSUnicodeStringEncoding] options:@{NSDocumentTypeDocumentAttribute: NSHTMLTextDocumentType} documentAttributes:nil error:&error];
-    NSRange range = NSMakeRange(0, attts.length);
-    NSMutableParagraphStyle *style =  [[NSMutableParagraphStyle alloc] init];
-    style.alignment = NSTextAlignmentCenter;
-    [attts addAttribute:NSParagraphStyleAttributeName value:style range:range];
-    
-    return attts;
 }
 
 #pragma mark - Accessibility

--- a/ResearchKit/Common/ORKQuestionStepViewController.m
+++ b/ResearchKit/Common/ORKQuestionStepViewController.m
@@ -171,8 +171,8 @@ typedef NS_ENUM(NSInteger, ORKQuestionSection) {
             _headerView = _tableContainer.stepHeaderView;
             _headerView.captionLabel.useSurveyMode = self.step.useSurveyMode;
             
-            _headerView.captionLabel.attributedText = [self getAttributedQuestionTitle];
-            _headerView.instructionLabel.attributedText = [self getAttributedQuestionText];
+            _headerView.captionLabel.attributedText = [_headerView getAttributedText:self.questionStep.title withFontSize:6];
+            _headerView.instructionLabel.attributedText = [_headerView getAttributedText:self.questionStep.text withFontSize:4];
             _headerView.learnMoreButtonItem = self.learnMoreButtonItem;
             
             _continueSkipView = _tableContainer.continueSkipContainerView;
@@ -244,34 +244,6 @@ typedef NS_ENUM(NSInteger, ORKQuestionSection) {
         self.continueButtonItem  = self.internalContinueButtonItem;
     }
     
-}
-
-- (NSAttributedString *)getAttributedQuestionTitle {
-    NSString *openFont = @"<font size='6' style='font-family:HelveticaNeue-Light'>";
-    NSString *closeFont = @"</font>";
-    NSString *customTitle = [NSString stringWithFormat:@"%@%@%@", openFont, self.questionStep.title, closeFont];
-    NSError *error = nil;
-    NSMutableAttributedString *attts = [[NSMutableAttributedString alloc] initWithData:[customTitle dataUsingEncoding:NSUnicodeStringEncoding] options:@{NSDocumentTypeDocumentAttribute: NSHTMLTextDocumentType} documentAttributes:nil error:&error];
-    NSRange range = NSMakeRange(0, attts.length);
-    NSMutableParagraphStyle *style =  [[NSMutableParagraphStyle alloc] init];
-    style.alignment = NSTextAlignmentCenter;
-    [attts addAttribute:NSParagraphStyleAttributeName value:style range:range];
-    
-    return attts;
-}
-
-- (NSAttributedString *)getAttributedQuestionText {
-    NSString *openFont = @"<font size='4' style='font-family:HelveticaNeue-Light'>";
-    NSString *closeFont = @"</font>";
-    NSString *customTitle = [NSString stringWithFormat:@"%@%@%@", openFont, self.questionStep.text, closeFont];
-    NSError *error = nil;
-    NSMutableAttributedString *attts = [[NSMutableAttributedString alloc] initWithData:[customTitle dataUsingEncoding:NSUnicodeStringEncoding] options:@{NSDocumentTypeDocumentAttribute: NSHTMLTextDocumentType} documentAttributes:nil error:&error];
-    NSRange range = NSMakeRange(0, attts.length);
-    NSMutableParagraphStyle *style =  [[NSMutableParagraphStyle alloc] init];
-    style.alignment = NSTextAlignmentCenter;
-    [attts addAttribute:NSParagraphStyleAttributeName value:style range:range];
-    
-    return attts;
 }
 
 - (void)viewDidLoad {

--- a/ResearchKit/Common/ORKQuestionStepViewController.m
+++ b/ResearchKit/Common/ORKQuestionStepViewController.m
@@ -170,8 +170,9 @@ typedef NS_ENUM(NSInteger, ORKQuestionSection) {
             
             _headerView = _tableContainer.stepHeaderView;
             _headerView.captionLabel.useSurveyMode = self.step.useSurveyMode;
-            _headerView.captionLabel.text = self.questionStep.title;
-            _headerView.instructionLabel.text = self.questionStep.text;
+            
+            _headerView.captionLabel.attributedText = [self getAttributedQuestionTitle];
+            _headerView.instructionLabel.attributedText = [self getAttributedQuestionText];
             _headerView.learnMoreButtonItem = self.learnMoreButtonItem;
             
             _continueSkipView = _tableContainer.continueSkipContainerView;
@@ -243,6 +244,34 @@ typedef NS_ENUM(NSInteger, ORKQuestionSection) {
         self.continueButtonItem  = self.internalContinueButtonItem;
     }
     
+}
+
+- (NSAttributedString *)getAttributedQuestionTitle {
+    NSString *openFont = @"<font size='6' style='font-family:HelveticaNeue-Light'>";
+    NSString *closeFont = @"</font>";
+    NSString *customTitle = [NSString stringWithFormat:@"%@%@%@", openFont, self.questionStep.title, closeFont];
+    NSError *error = nil;
+    NSMutableAttributedString *attts = [[NSMutableAttributedString alloc] initWithData:[customTitle dataUsingEncoding:NSUnicodeStringEncoding] options:@{NSDocumentTypeDocumentAttribute: NSHTMLTextDocumentType} documentAttributes:nil error:&error];
+    NSRange range = NSMakeRange(0, attts.length);
+    NSMutableParagraphStyle *style =  [[NSMutableParagraphStyle alloc] init];
+    style.alignment = NSTextAlignmentCenter;
+    [attts addAttribute:NSParagraphStyleAttributeName value:style range:range];
+    
+    return attts;
+}
+
+- (NSAttributedString *)getAttributedQuestionText {
+    NSString *openFont = @"<font size='4' style='font-family:HelveticaNeue-Light'>";
+    NSString *closeFont = @"</font>";
+    NSString *customTitle = [NSString stringWithFormat:@"%@%@%@", openFont, self.questionStep.text, closeFont];
+    NSError *error = nil;
+    NSMutableAttributedString *attts = [[NSMutableAttributedString alloc] initWithData:[customTitle dataUsingEncoding:NSUnicodeStringEncoding] options:@{NSDocumentTypeDocumentAttribute: NSHTMLTextDocumentType} documentAttributes:nil error:&error];
+    NSRange range = NSMakeRange(0, attts.length);
+    NSMutableParagraphStyle *style =  [[NSMutableParagraphStyle alloc] init];
+    style.alignment = NSTextAlignmentCenter;
+    [attts addAttribute:NSParagraphStyleAttributeName value:style range:range];
+    
+    return attts;
 }
 
 - (void)viewDidLoad {

--- a/ResearchKit/Common/ORKStepHeaderView.h
+++ b/ResearchKit/Common/ORKStepHeaderView.h
@@ -38,6 +38,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, strong, nullable) UIBarButtonItem *learnMoreButtonItem;
 
+- (NSAttributedString *)getAttributedText:(NSString *)text withFontSize:(NSInteger)fontSize;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ResearchKit/Common/ORKStepHeaderView.m
+++ b/ResearchKit/Common/ORKStepHeaderView.m
@@ -442,4 +442,18 @@ const CGFloat IconHeight = 60;
     [super updateConstraints];
 }
 
+- (NSAttributedString *)getAttributedText:(NSString *)text withFontSize:(NSInteger)fontSize {
+    NSString *openFont = [NSString stringWithFormat:@"<font size='%d' style='font-family:HelveticaNeue-Light'>", fontSize];
+    NSString *closeFont = @"</font>";
+    NSString *customTitle = [NSString stringWithFormat:@"%@%@%@", openFont, text, closeFont];
+    NSError *error = nil;
+    NSMutableAttributedString *attts = [[NSMutableAttributedString alloc] initWithData:[customTitle dataUsingEncoding:NSUnicodeStringEncoding] options:@{NSDocumentTypeDocumentAttribute: NSHTMLTextDocumentType} documentAttributes:nil error:&error];
+    NSRange range = NSMakeRange(0, attts.length);
+    NSMutableParagraphStyle *style =  [[NSMutableParagraphStyle alloc] init];
+    style.alignment = NSTextAlignmentCenter;
+    [attts addAttribute:NSParagraphStyleAttributeName value:style range:range];
+    
+    return attts;
+}
+
 @end

--- a/ResearchKit/Consent/ORKConsentSceneViewController.m
+++ b/ResearchKit/Consent/ORKConsentSceneViewController.m
@@ -76,24 +76,11 @@
     self.headerView.captionLabel.text = consentSection.title;
     
     self.imageView.image = consentSection.image;
-    self.headerView.instructionLabel.attributedText = [self getAttributedSummary:consentSection.summary];
+    self.headerView.instructionLabel.attributedText = [self.headerView getAttributedText:consentSection.summary withFontSize:5];
+    [self getAttributedSummary:consentSection.summary];
     
     self.continueSkipContainer.continueEnabled = YES;
     [self.continueSkipContainer updateContinueAndSkipEnabled];
-}
-
-- (NSAttributedString *)getAttributedSummary:(NSString *)summary {
-    NSString *openFont = @"<font size='5' style='font-family:HelveticaNeue-Light'>";
-    NSString *closeFont = @"</font>";
-    NSString *customTitle = [NSString stringWithFormat:@"%@%@%@", openFont, summary, closeFont];
-    NSError *error = nil;
-    NSMutableAttributedString *attts = [[NSMutableAttributedString alloc] initWithData:[customTitle dataUsingEncoding:NSUnicodeStringEncoding] options:@{NSDocumentTypeDocumentAttribute: NSHTMLTextDocumentType} documentAttributes:nil error:&error];
-    NSRange range = NSMakeRange(0, attts.length);
-    NSMutableParagraphStyle *style =  [[NSMutableParagraphStyle alloc] init];
-    style.alignment = NSTextAlignmentCenter;
-    [attts addAttribute:NSParagraphStyleAttributeName value:style range:range];
-    
-    return attts;
 }
 
 @end

--- a/ResearchKit/Consent/ORKConsentSceneViewController.m
+++ b/ResearchKit/Consent/ORKConsentSceneViewController.m
@@ -76,10 +76,24 @@
     self.headerView.captionLabel.text = consentSection.title;
     
     self.imageView.image = consentSection.image;
-    self.headerView.instructionLabel.text = [consentSection summary];
+    self.headerView.instructionLabel.attributedText = [self getAttributedSummary:consentSection.summary];
     
     self.continueSkipContainer.continueEnabled = YES;
     [self.continueSkipContainer updateContinueAndSkipEnabled];
+}
+
+- (NSAttributedString *)getAttributedSummary:(NSString *)summary {
+    NSString *openFont = @"<font size='5' style='font-family:HelveticaNeue-Light'>";
+    NSString *closeFont = @"</font>";
+    NSString *customTitle = [NSString stringWithFormat:@"%@%@%@", openFont, summary, closeFont];
+    NSError *error = nil;
+    NSMutableAttributedString *attts = [[NSMutableAttributedString alloc] initWithData:[customTitle dataUsingEncoding:NSUnicodeStringEncoding] options:@{NSDocumentTypeDocumentAttribute: NSHTMLTextDocumentType} documentAttributes:nil error:&error];
+    NSRange range = NSMakeRange(0, attts.length);
+    NSMutableParagraphStyle *style =  [[NSMutableParagraphStyle alloc] init];
+    style.alignment = NSTextAlignmentCenter;
+    [attts addAttribute:NSParagraphStyleAttributeName value:style range:range];
+    
+    return attts;
 }
 
 @end


### PR DESCRIPTION
### Description

Allow ResearchKit to use HTML tags on Questions text and instructions.
Also allow ResearchKit to use HTML tags on Consent summary.

### Acceptance Criteria

- [ ] Open application and check that question text have bold/italic words
- [ ] Idem for Consent document

Note: It is necessary to receive the texts with HTML tags from the server