### PR TITLE
Don't scroll the tableview if the becoming field is a textfield.

### DIFF
--- a/ResearchKit/Common/ORKFormStepViewController.m
+++ b/ResearchKit/Common/ORKFormStepViewController.m
@@ -954,7 +954,7 @@
 - (void)formItemCellDidBecomeFirstResponder:(ORKFormItemCell *)cell {
     _currentFirstResponderCell = cell;
     NSIndexPath *path = [_tableView indexPathForCell:cell];
-    if (path) {
+    if (path && ![cell isKindOfClass:[ORKFormItemTextFieldCell class]]) {
         [_tableContainer scrollCellVisible:cell animated:YES];
     }
 }


### PR DESCRIPTION
### Description 

* When the user touches in the First Name field and we bring the keyboard up, we should move the names up so that both are above the keyboard.

![simulator screen shot - iphone 6s - 2018-09-21 at 12 28 53](https://user-images.githubusercontent.com/8496248/45890734-0fa6c100-bd9a-11e8-8aa2-561d76fb41c7.png)
