### PR TITLE
Fixes/keyboard hide field on consent

### DIFF
--- a/ResearchKit/Common/ORKFormItemCell.m
+++ b/ResearchKit/Common/ORKFormItemCell.m
@@ -467,13 +467,6 @@ static const CGFloat HorizontalMargin = 15.0;
     return YES;
 }
 
-- (void)textFieldDidBeginEditing:(UITextField *)textField {
-    // Ask table view to adjust scrollview's position
-    self.editingHighlight = YES;
-    [self.delegate formItemCellDidBecomeFirstResponder:self];
-    UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification, nil);
-}
-
 - (BOOL)textFieldShouldEndEditing:(UITextField *)textField {
     if (textField.text.length > 0 && ![[self.formItem impliedAnswerFormat] isAnswerValidWithString:textField.text]) {
         [self showValidityAlertWithMessage:[[self.formItem impliedAnswerFormat] localizedInvalidValueStringWithAnswerString:textField.text]];

--- a/ResearchKit/Common/ORKStep.h
+++ b/ResearchKit/Common/ORKStep.h
@@ -138,6 +138,7 @@ ORK_CLASS_AVAILABLE
  The primary text to display for the step in a localized string.
  */
 @property (nonatomic, copy, nullable) NSString *title;
+
 /**
  Additional text to display for the step in a localized string.
  

--- a/ResearchKit/Common/ORKStep.h
+++ b/ResearchKit/Common/ORKStep.h
@@ -138,7 +138,6 @@ ORK_CLASS_AVAILABLE
  The primary text to display for the step in a localized string.
  */
 @property (nonatomic, copy, nullable) NSString *title;
-@property (nonatomic, copy, nullable) NSAttributedString *attributedTitle;
 /**
  Additional text to display for the step in a localized string.
  
@@ -147,7 +146,6 @@ ORK_CLASS_AVAILABLE
  the `text` property.
  */
 @property (nonatomic, copy, nullable) NSString *text;
-@property (nonatomic, copy, nullable) NSAttributedString *attributedText;
 
 /**
  The task that contains the step.

--- a/ResearchKit/Common/ORKStep.h
+++ b/ResearchKit/Common/ORKStep.h
@@ -138,7 +138,7 @@ ORK_CLASS_AVAILABLE
  The primary text to display for the step in a localized string.
  */
 @property (nonatomic, copy, nullable) NSString *title;
-
+@property (nonatomic, copy, nullable) NSAttributedString *attributedTitle;
 /**
  Additional text to display for the step in a localized string.
  
@@ -147,6 +147,7 @@ ORK_CLASS_AVAILABLE
  the `text` property.
  */
 @property (nonatomic, copy, nullable) NSString *text;
+@property (nonatomic, copy, nullable) NSAttributedString *attributedText;
 
 /**
  The task that contains the step.


### PR DESCRIPTION
### Description

* Last Name field on Consent signing was hidden by the keyboard, so we removed the management of the scroll view to ResearchKit and now is IQKeyboardManager who manage the fields.

![Simulator Screen Shot - iPhone 8 - 2019-05-16 at 13 21 32](https://user-images.githubusercontent.com/8496248/57870731-10cfa700-77de-11e9-8fb6-0ab02829efd8.png)
