### PR TITLE
Show missing "Thank you" screen

### DIFF
--- a/ResearchKit/Common/ORKNavigableOrderedTask.m
+++ b/ResearchKit/Common/ORKNavigableOrderedTask.m
@@ -178,6 +178,9 @@
     if ([navigationRules count] > 0 && nextStep == nil) {
         ORKStepNavigationRule *rule = navigationRules.firstObject;
         NSString *stepID = [rule defaultStepIdentifier];
+        if ([stepID isEqualToString:@"-1"]) {
+            stepID = @"ThankYouScreen";
+        }
         nextStep = [self stepWithIdentifier:stepID];
     } else if ([navigationRules count] == 0 || nextStep == nil) {
         nextStep = [super stepAfterStep:step withResult:result];


### PR DESCRIPTION
### Description

Show ThankYou screen when the default step identifier of the next step is `-1`

![Simulator Screen Shot - iPhone XR - 2019-06-04 at 14 59 16](https://user-images.githubusercontent.com/8496248/58902518-9fe32700-86d9-11e9-9282-1e925b1a5c26.png)
